### PR TITLE
Move nix_commands to defaults to allow overriding

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 nix_version: 2.16.0
 installer_checksum: sha512:281e5d44c54ebeda71135aab47a73dd8db0a7cdc6cef8523a9f02b3097a53784ac83489ae8116dae15df6297910f7cbcd27532f16c1a38aa025b549b6a98da5e
 flakes: false
+nix_commands: []

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,3 @@
 ---
 nix_build: nix-{{ nix_version }}-x86_64-linux
 installer_path: https://releases.nixos.org/nix/nix-{{ nix_version }}/{{ nix_build }}.tar.xz
-nix_commands: []


### PR DESCRIPTION
This was raised in #10.

> nix_commands is hard to override because it is defined in /vars. Ansible only has a few ways to override vars defined this way: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#understanding-variable-precedence
>
> It would be great if I could override this with var_files or group_vars for example.

Thanks to @mjmaurer for the suggestion.