### PR TITLE
Architecture from facts and checksum from release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ Role Variables
 nix_version -- The version of nix to download and install.
 If unset this role will take the latest nix version it has been tested with.
 
-installer_checksum -- A checksum for the installer binary.
-You will need to change this if you change the nix version that is downloaded.
-It's easiest to let this fail and fix the error since the error is clear and provides the new checksum value to copy in.
-
 nix_commands -- Optional list of shell commands to run in an environment with nix and the running nix daemon.
 
 flakes -- Set to enable nix flake commands.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 nix_version: 2.31.1
-installer_checksum: sha256:75f18f5d567bb8c7b5d62155f8c852e62ffac0c81acda02f52b998281e3603ce
 flakes: false
 nix_commands: []
 remove_nix_directory: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,11 +12,16 @@
   when: nix_version_output.rc == 0
 - name: Download and run installer
   block:
+    - name: Fetch checksum
+      ansible.builtin.uri:
+        url: "{{ installer_path }}.sha256"
+        return_content: yes
+      register: checksum_file
     - name: Download installer
       get_url:
         url: "{{ installer_path }}"
         dest: /tmp
-        checksum: "{{ installer_checksum }}"
+        checksum: "sha256:{{ checksum_file.content }}"
     - name: extract installer
       unarchive:
         src: /tmp/{{ nix_build }}.tar.xz

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
 ---
-nix_build: nix-{{ nix_version }}-x86_64-linux
+nix_build: nix-{{ nix_version }}-{{ ansible_architecture }}-linux
 installer_path: https://releases.nixos.org/nix/nix-{{ nix_version }}/{{ nix_build }}.tar.xz


### PR DESCRIPTION
Let Ansible discover host architecture.
* Allows supporting aarch64 using the same code.

Download checksum from Nix release site.
* Makes supporting multiple architectures easier.