### PR TITLE
Replace ignore_errors with failed_when on version check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   shell: |
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
     nix --version
-  ignore_errors: true
+  failed_when: false
   changed_when: false
   register: nix_version_output
 - name: Set nix version name


### PR DESCRIPTION
The "Get nix version" task uses `ignore_errors: true` to handle the case where Nix is not yet installed. While functionally correct, this causes Ansible to display the expected failure in red as an [ERROR], which is misleading. Using `failed_when: false` achieves the same behavior without the alarming output.